### PR TITLE
Also add extracted object properties to the bulk response

### DIFF
--- a/spec/Phpro/Apigility/Doctrine/Bulk/Listener/AbstractListenerSpec.php
+++ b/spec/Phpro/Apigility/Doctrine/Bulk/Listener/AbstractListenerSpec.php
@@ -17,7 +17,7 @@ abstract class AbstractListenerSpec extends ObjectBehavior
     {
         $className = 'stdClass';
         $this->beConstructedWith($objectManager, $className, $hydrator);
-        $this->stubMetaData($objectManager);
+        $this->stubMetaData($objectManager, $hydrator);
     }
 
     public function it_is_a_bulk_listener()
@@ -28,12 +28,14 @@ abstract class AbstractListenerSpec extends ObjectBehavior
     /**
      * @param \Doctrine\Common\Persistence\ObjectManager $objectManager
      */
-    protected function stubMetaData($objectManager)
+    protected function stubMetaData($objectManager, $hydrator)
     {
         $prophet = new Prophet();
         $meta = $prophet->prophesize('Doctrine\Common\Persistence\Mapping\ClassMetadata');
         $meta->getIdentifierFieldNames()->willReturn(['id']);
         $meta->getIdentifierValues(Argument::any())->willReturn([1]);
+
+        $hydrator->extract(Argument::type('stdClass'))->willReturn(['id' => 1]);
 
         $objectManager->getClassMetadata('stdClass')->willReturn($meta);
     }

--- a/src/Phpro/Apigility/Doctrine/Bulk/Listener/AbstractListener.php
+++ b/src/Phpro/Apigility/Doctrine/Bulk/Listener/AbstractListener.php
@@ -77,15 +77,25 @@ abstract class AbstractListener extends AbstractListenerAggregate
     /**
      * @param $command
      * @param $entity
+     * @param bool $addExtractedEntity
      *
      * @return Result
      */
-    protected function createResult($command, $entity)
+    protected function createResult($command, $entity, $addExtractedEntity = true)
     {
         $meta = $this->objectManager->getClassMetadata($this->className);
         $identifiers = $meta->getIdentifierValues($entity);
 
-        return new Result($command, current($identifiers));
+        $result = new Result($command, current($identifiers));
+
+        if (!$addExtractedEntity) {
+            return $result;
+        }
+
+        $data = $this->hydrator->extract($entity);
+        $result->addParams(['item' => $data]);
+
+        return $result;
     }
 
 }

--- a/src/Phpro/Apigility/Doctrine/Bulk/Listener/CustomCommandListener.php
+++ b/src/Phpro/Apigility/Doctrine/Bulk/Listener/CustomCommandListener.php
@@ -43,7 +43,7 @@ class CustomCommandListener extends AbstractListener
         $this->saveEntity($entity);
 
         $event->stopPropagation(true);
-        $result = $this->createResult($command, $entity);
+        $result = $this->createResult($command, $entity, false);
 
         // Add params:
         if (is_array($response)) {


### PR DESCRIPTION
The "params.item" property of the result/response contains the extracted object data after a delete, update or create command. This feature is not implemented for custom command listeners.
